### PR TITLE
Refactor state management to use StateScoped instead of explicit cleanup

### DIFF
--- a/src/game_over.rs
+++ b/src/game_over.rs
@@ -6,7 +6,6 @@ use crate::{
     settings::DifficultySetting,
     stats::Stats,
     ui::{UiAssets, BUTTON_TEXT, TITLE_TEXT},
-    util::cleanup,
     GameState,
 };
 
@@ -14,13 +13,9 @@ pub struct GameOverPlugin;
 impl Plugin for GameOverPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(OnEnter(GameState::GameOver), init);
-        app.add_systems(OnExit(GameState::GameOver), cleanup::<GameOverScene>);
         app.add_systems(Update, menu_button.run_if(in_state(GameState::GameOver)));
     }
 }
-
-#[derive(Component)]
-struct GameOverScene;
 
 #[derive(Component)]
 struct MenuButton;
@@ -67,7 +62,7 @@ fn init(
                 ..default()
             },
             NineSliceUiTexture::from_image(ui_assets.nine_panel.clone()),
-            GameOverScene,
+            StateScoped(GameState::GameOver),
         ))
         .id();
 

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -10,7 +10,6 @@ use crate::{
     enemy::EnemyKind,
     tilemap::{AtlasHandle, TileKind},
     ui::UiAssets,
-    util::cleanup,
     GameState,
 };
 
@@ -34,13 +33,9 @@ impl Plugin for LoadingPlugin {
             .add_systems(
                 Update,
                 log_pipelines.run_if(resource_changed::<PipelinesReady>),
-            )
-            .add_systems(OnExit(GameState::Loading), cleanup::<LoadingScene>);
+            );
     }
 }
-
-#[derive(Component)]
-struct LoadingScene;
 
 #[derive(Component)]
 pub struct LoadingImage {
@@ -105,7 +100,7 @@ fn init_loading_scene(
                 ..default()
             },
             NineSliceUiTexture::from_image(ui_assets.nine_button.clone()),
-            LoadingScene,
+            StateScoped(GameState::Loading),
         ))
         .with_children(|parent| {
             parent.spawn(TextBundle {

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,8 @@ fn main() {
 
     app.insert_resource(Msaa::Off)
         .insert_resource(ClearColor(Color::BLACK))
-        .init_state::<GameState>();
+        .init_state::<GameState>()
+        .enable_state_scoped_entities::<GameState>();
 
     app.run();
 }

--- a/src/main_menu.rs
+++ b/src/main_menu.rs
@@ -31,15 +31,9 @@ impl Plugin for MainMenuPlugin {
                 )
                     .run_if(in_state(GameState::MainMenu)),
             )
-            .add_systems(
-                OnExit(GameState::MainMenu),
-                (crate::util::cleanup::<MainMenuScene>, cleanup_background),
-            );
+            .add_systems(OnExit(GameState::MainMenu), cleanup_background);
     }
 }
-
-#[derive(Component)]
-struct MainMenuScene;
 
 #[derive(Resource)]
 struct MainMenuAssets {
@@ -122,7 +116,7 @@ fn setup_menu(
                 ..default()
             },
             NineSliceUiTexture::from_image(ui_assets.nine_panel.clone()),
-            MainMenuScene,
+            StateScoped(GameState::MainMenu),
         ))
         .id();
 


### PR DESCRIPTION
Replace explicit cleanup systems with [StateScoped] components to manage state transitions more efficiently.
This change simplifies the plugin systems by removing the need for dedicated cleanup systems for some scenes.

[StateScoped]: https://bevyengine.org/news/bevy-0-14/#state-scoped-entities